### PR TITLE
Show writing area as a page

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -4,3 +4,13 @@
     border-left: none;
     border-right: none;
 }
+
+.page-decoration {
+    background-color: #ffffff;
+    border: none;
+    border-color: transparent;
+    box-shadow:
+        0 0 0 1px alpha (#000, 0.05),
+        0 3px 3px alpha (#000, 0.22);
+    transition: all 150ms ease-in-out;
+}

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -20,6 +20,7 @@ public class Writer.MainWindow : Gtk.Window {
     public TextEditor editor { get; construct; }
     private Widgets.TitleBar title_bar;
     public Gtk.Stack stack { get; private set; }
+    private Views.EditorView editor_view;
 
     public MainWindow (Application app, TextEditor editor) {
         Object (
@@ -43,7 +44,7 @@ public class Writer.MainWindow : Gtk.Window {
         stack.transition_duration = 200;
         stack.transition_type = Gtk.StackTransitionType.SLIDE_LEFT_RIGHT;
 
-        var editor_view = new Views.EditorView (editor);
+        editor_view = new Views.EditorView (editor);
         var welcome_view = new Views.WelcomeView (app);
 
         stack.add_named (welcome_view, "welcome");
@@ -101,6 +102,8 @@ public class Writer.MainWindow : Gtk.Window {
         Application.settings.set_int ("window-width", w);
         Application.settings.set_int ("window-height", h);
         Application.settings.set_boolean ("is-maximized", m);
+
+        editor_view.document_view.queue_draw ();
 
         return base.configure_event (event);
     }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -105,6 +105,7 @@ public class Writer.MainWindow : Gtk.Window {
 
         // Redraw document_view when window is resized or maximized/unmaximized, otherwise the view will be broken
         editor_view.document_view.queue_draw ();
+        editor_view.document_view_wrapper.queue_draw ();
 
         return base.configure_event (event);
     }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -105,10 +105,6 @@ public class Writer.MainWindow : Gtk.Window {
 
         // Redraw document_view when window is resized or maximized/unmaximized, otherwise the view will be broken
         editor_view.document_view.queue_draw ();
-        window_state_event.connect (() => {
-            editor_view.document_view.queue_draw ();
-            return true;
-        });
 
         return base.configure_event (event);
     }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -103,7 +103,12 @@ public class Writer.MainWindow : Gtk.Window {
         Application.settings.set_int ("window-height", h);
         Application.settings.set_boolean ("is-maximized", m);
 
+        // Redraw document_view when window is resized or maximized/unmaximized, otherwise the view will be broken
         editor_view.document_view.queue_draw ();
+        window_state_event.connect (() => {
+            editor_view.document_view.queue_draw ();
+            return true;
+        });
 
         return base.configure_event (event);
     }

--- a/src/Utils/TextEditor.vala
+++ b/src/Utils/TextEditor.vala
@@ -30,6 +30,9 @@ public class Writer.TextEditor : Gtk.TextBuffer {
         text_view = new Gtk.TextView.with_buffer (this);
         text_view.pixels_below_lines = 20;
         text_view.wrap_mode = Gtk.WrapMode.WORD_CHAR;
+        text_view.hexpand = true;
+        text_view.vexpand = true;
+        text_view.margin = 48;
 
         text_view.key_press_event.connect (key_press_callback);
         text_view.move_cursor.connect (cursor_moved_callback);

--- a/src/Views/EditorView.vala
+++ b/src/Views/EditorView.vala
@@ -20,6 +20,7 @@
 
 public class Writer.Views.EditorView : Gtk.Box {
     public TextEditor editor { get; construct; }
+    public Gtk.Grid document_view { get; private set; }
 
     public EditorView (TextEditor editor) {
         Object (
@@ -32,7 +33,7 @@ public class Writer.Views.EditorView : Gtk.Box {
     construct {
         var toolbar = new Widgets.ToolBar (editor);
 
-        var document_view = new Gtk.Grid ();
+        document_view = new Gtk.Grid ();
         document_view.get_style_context ().add_class ("page-decoration");
         document_view.margin = 24;
         // Set document_view size to A4 size

--- a/src/Views/EditorView.vala
+++ b/src/Views/EditorView.vala
@@ -29,9 +29,21 @@ public class Writer.Views.EditorView : Gtk.Box {
     construct {
         var toolbar = new Widgets.ToolBar (editor);
 
+        var document_view = new Gtk.Grid ();
+        document_view.get_style_context ().add_class ("page-decoration");
+        document_view.margin = 24;
+        // Set document_view size to A4 size
+        document_view.height_request = 1123;
+        document_view.width_request = 794;
+        document_view.add (editor.text_view);
+
+        var document_view_wrapper = new Gtk.Grid ();
+        document_view_wrapper.halign = Gtk.Align.CENTER;
+        document_view_wrapper.valign = Gtk.Align.CENTER;
+        document_view_wrapper.add (document_view);
+
         var scrolled_window = new Gtk.ScrolledWindow (null, null);
-        scrolled_window.border_width = 20;
-        scrolled_window.add (editor.text_view);
+        scrolled_window.add (document_view_wrapper);
 
         pack_start (toolbar, false, false, 0);
         pack_start (scrolled_window, true, true, 0);

--- a/src/Views/EditorView.vala
+++ b/src/Views/EditorView.vala
@@ -13,6 +13,9 @@
 *
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*
+* The way to show writing area as a page is inspired from
+* https://github.com/aggalex/OfficeWorks-Author/blob/master/src/views/EditView.vala
 */
 
 public class Writer.Views.EditorView : Gtk.Box {

--- a/src/Views/EditorView.vala
+++ b/src/Views/EditorView.vala
@@ -21,6 +21,7 @@
 public class Writer.Views.EditorView : Gtk.Box {
     public TextEditor editor { get; construct; }
     public Gtk.Grid document_view { get; private set; }
+    public Gtk.Grid document_view_wrapper { get; private set; }
 
     public EditorView (TextEditor editor) {
         Object (
@@ -41,7 +42,7 @@ public class Writer.Views.EditorView : Gtk.Box {
         document_view.width_request = 794;
         document_view.add (editor.text_view);
 
-        var document_view_wrapper = new Gtk.Grid ();
+        document_view_wrapper = new Gtk.Grid ();
         document_view_wrapper.halign = Gtk.Align.CENTER;
         document_view_wrapper.valign = Gtk.Align.CENTER;
         document_view_wrapper.add (document_view);


### PR DESCRIPTION
![Screenshot from 2019-07-12 10-42-25](https://user-images.githubusercontent.com/26003928/61099633-ee849d80-a49d-11e9-8b88-bd698efa7f06.png)

Fixes #5

## TODO

* [x] Fix the page is not rendered correctly when resizing the app window like this:

![2019-07-12 23 14 57 の画面録画](https://user-images.githubusercontent.com/26003928/61134607-edce2480-a4fa-11e9-85a5-15e1303d5448.gif)
