### PR TITLE
Flatpak: Use id instead of deprecated app-id

### DIFF
--- a/com.github.ryonakano.writer.yml
+++ b/com.github.ryonakano.writer.yml
@@ -1,4 +1,4 @@
-app-id: com.github.ryonakano.writer
+id: com.github.ryonakano.writer
 runtime: io.elementary.Platform
 runtime-version: '7.2'
 sdk: io.elementary.Sdk


### PR DESCRIPTION
From https://docs.flatpak.org/en/latest/flatpak-builder-command-reference.html:

> Note, "app-id" is deprecated and preserved only for backwards compatibility.